### PR TITLE
!rollgp command

### DIFF
--- a/src/db/player.rs
+++ b/src/db/player.rs
@@ -38,6 +38,16 @@ pub struct Player {
     // Enchant metadata
     #[serde(default)]
     pub enchants_rolled: u64,
+
+    // Gunpowder metadata
+    #[serde(default)]
+    pub gp_rolled: u64,
+    #[serde(default)]
+    pub gp_acc: u64,
+    #[serde(default)]
+    pub best_gp: u64,
+    #[serde(default)]
+    pub max_gp_rolled: u32,
 }
 
 #[derive(Default)]
@@ -45,6 +55,7 @@ pub struct PlayerScratch {
     pub last_trident: i32,
     pub greeted: bool,
     pub trident_response_timer: u64,
+    pub gp_ratelimit: u64,
 }
 
 impl PlayerScratch {
@@ -53,6 +64,7 @@ impl PlayerScratch {
             last_trident: -1,
             greeted: false,
             trident_response_timer: 0,
+            gp_ratelimit: 0,
         }
     }
 


### PR DESCRIPTION
New command that rolls gunpowder.

There are 4 chests in a desert pyramid, with 4 rolls each from the pool containing gunpowder with a 20% (10/50) chance of selecting. The stack size can be between 1 and 8 inclusively.

Tracks players' pb, accumulative gunpowder, and number of rolls. Death has a 1/3 chance of occurring if the player rolls a zero.

Includes silent rate-limiter. User enters a 2-second cool down when rolling gunpowder. If they attempt to roll again during a cool down period, it will extend itself another 2 seconds. The cool down can accumulate a maximum of 61 seconds. No feedback is provided to the user during cool down (hence silent).