### PR TITLE
Pull AA Leaderboard from spreadsheet

### DIFF
--- a/src/commands/aaleaderboard.rs
+++ b/src/commands/aaleaderboard.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use itertools::Itertools;
+use rand::{thread_rng, Rng};
 
 macro_rules! return_if_err {
     ($e:expr) => {
@@ -16,7 +17,7 @@ macro_rules! return_if_err {
 
 const DEFAULT_SPREADSHEET_ID: &str = "107ijqjELTQQ29KW4phUmtvYFTX9-pfHsjb18TKoWACk";
 const DEFAULT_WORKSHEET_ID: i64 = 1706556435;
-const STREAMER_NAME: &str = "desktopfolder";
+const STREAMER_NAME: &str = "DesktopFolder";
 
 struct AAPlayer {
     name: String,
@@ -109,10 +110,16 @@ impl AALeaderboard {
 
     pub fn top_info(&self) -> String {
         let lb = return_if_err!(self.get_data());
-        let top5 = lb.leaderboard
+        let fake = thread_rng().gen_bool(1.0 / 8.0);
+        let top5 = lb
+            .leaderboard
             .iter()
             .take(5)
-            .map(|p| p.to_string())
+            .map(if fake {
+                |p: &Arc<AAPlayer>| format!("{} ({})", &STREAMER_NAME, p.igt)
+            } else {
+                |p: &Arc<AAPlayer>| p.to_string()
+            })
             .join(" | ");
         format!("Top 5 AA runs: {}", top5)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1169,7 +1169,7 @@ impl IRCBotClient {
             }
             "feature:aaleaderboard" => {
                 self.aa_leaderboard.fetch_if_required().await;
-                let trimmed_args = args.trim_matches(|c: char| !c.is_alphanumeric()); // get random characters at end of messages sometimes
+                let trimmed_args = args.trim(); // get random spaces at end of messages sometimes
                 let msg = if trimmed_args.is_empty() {
                     format!("{}. Try \"!aalb top\" to see the top 5 runs. You can also search a rank or player with \"!aalb <rank/name>\".", self.aa_leaderboard.info_for_streamer())
                 } else if trimmed_args == "top" {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1169,13 +1169,14 @@ impl IRCBotClient {
             }
             "feature:aaleaderboard" => {
                 self.aa_leaderboard.fetch_if_required().await;
-                let trimmed_args = args.trim(); // get random spaces at end of messages sometimes
+                let trimmed_args = args.trim_matches(|c: char| !c.is_alphanumeric()); // get random characters at end of messages sometimes
                 let msg = if trimmed_args.is_empty() {
                     format!("{}. Try \"!aalb top\" to see the top 5 runs. You can also search a rank or player with \"!aalb <rank/name>\".", self.aa_leaderboard.info_for_streamer())
                 } else if trimmed_args == "top" {
                     self.aa_leaderboard.top_info()
-                } else if trimmed_args == "stat" {
-                    self.aa_leaderboard.last_update()
+                } else if trimmed_args == "reload" && self.ct.admins.contains(&user) {
+                    self.aa_leaderboard.unload();
+                    "OK, I will reload the leaderboard folderSus".to_string()
                 } else {
                     // if someone has a username that's all numbers, lol gg
                     match trimmed_args.parse::<u32>().ok() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1169,7 +1169,7 @@ impl IRCBotClient {
             }
             "feature:aaleaderboard" => {
                 self.aa_leaderboard.fetch_if_required().await;
-                let trimmed_args = args.trim(); // get random spaces at end of messages sometimes
+                let trimmed_args = args.trim_right_matches(|c: char| !c.is_ascii() || c.is_whitespace()); // get random characters at end of messages sometimes
                 let msg = if trimmed_args.is_empty() {
                     format!("{}. Try \"!aalb top\" to see the top 5 runs. You can also search a rank or player with \"!aalb <rank/name>\".", self.aa_leaderboard.info_for_streamer())
                 } else if trimmed_args == "top" {


### PR DESCRIPTION
Use Google Doc CSV export to source the leaderboard directly instead of pulling from a data dump stored on Github.

The URL it pulls from is: `https://docs.google.com/spreadsheets/d/{SPREADSHEET}/export?gid={WORKSHEET}&format=csv`

The `stat` sub-command has been removed because the bot now sources up-to-date data. A `reload` sub-command has been added for admins which will force the bot to pull fresh from the spreadsheet.

Leaderboard is no longer limited to the top 100 players. 

The CSV deserialising code is very ugly - no judging pls.