### PR TITLE
Fix some potential crashes in AA Leaderboard

### DIFF
--- a/src/commands/aaleaderboard.rs
+++ b/src/commands/aaleaderboard.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use itertools::Itertools;
+use lazy_static::lazy_static;
 use rand::{thread_rng, Rng};
+use reqwest::Client;
 
 macro_rules! return_if_err {
     ($e:expr) => {
@@ -55,15 +57,17 @@ impl AALeaderboard {
         Self { ..Default::default() }
     }
 
-    pub async fn fetch_if_required(&mut self) {
+    /// Returns a string if failed to fetch the leaderboard
+    pub async fn fetch_if_required(&mut self) -> Option<String> {
         let now = SystemTime::now();
 
         if self.data.is_none() || self.next_fetch.map(|t| t <= now).unwrap_or(true) {
-            self.fetch().await
+            return self.fetch().await
         }
+        None
     }
 
-    pub async fn fetch(&mut self) {
+    pub async fn fetch(&mut self) -> Option<String> {
         const REFRESH_AFTER: Duration = Duration::from_secs(60 * 60);
         const RETRY_AFTER: Duration = Duration::from_secs(60 * 5);
 
@@ -76,8 +80,22 @@ impl AALeaderboard {
                 .unwrap_or(DEFAULT_WORKSHEET_ID),
         );
 
-        self.data = dl.fetch().await;
-        self.next_fetch = Some(SystemTime::now() + self.data.as_ref().map(|_| REFRESH_AFTER).unwrap_or(RETRY_AFTER));
+        match dl.fetch().await {
+            Ok(res) => {
+                self.data = Some(res);
+                self.next_fetch = Some(SystemTime::now() + REFRESH_AFTER);
+                None
+            },
+            Err(err) => {
+                self.data = None;
+                self.next_fetch = Some(SystemTime::now() + RETRY_AFTER);
+                Some(match err {
+                    FetchError::Timeout => "Oh no, it's taking too long to read the leaderboard. sajj Am I rate-limited?".to_string(),
+                    FetchError::Internal => "If you're seeing this message, then Toto is a bad dev.".to_string(),
+                    _ => "I wasn't able to read the leaderboard. sajj".to_string(),
+                })
+            },
+        }
     }
 
     pub fn unload(&mut self) {
@@ -91,7 +109,8 @@ impl AALeaderboard {
 
     pub fn info_at_rank(&self, rank: u32) -> String {
         let lb = return_if_err!(self.get_data());
-        lb.leaderboard.get(rank as usize - 1)
+        let idx = return_if_err!((rank as usize).checked_sub(1).ok_or_else(|| "Uhhh, how did we get here?".to_string()));
+        lb.leaderboard.get(idx)
             .map(|p| p.to_rank_info())
             .unwrap_or_else(|| format!("I can't find a player at #{}. Hmmge", rank))
     }
@@ -110,18 +129,31 @@ impl AALeaderboard {
 
     pub fn top_info(&self) -> String {
         let lb = return_if_err!(self.get_data());
-        let fake = thread_rng().gen_bool(1.0 / 8.0);
         let top5 = lb
             .leaderboard
             .iter()
             .take(5)
-            .map(if fake {
+            .map(if thread_rng().gen_bool(1.0 / 8.0) {
                 |p: &Arc<AAPlayer>| format!("{} ({})", &STREAMER_NAME, p.igt)
             } else {
                 |p: &Arc<AAPlayer>| p.to_string()
             })
             .join(" | ");
         format!("Top 5 AA runs: {}", top5)
+    }
+
+    pub fn best_time(&self) -> String {
+        let lb = return_if_err!(self.get_data());
+        lb.leaderboard.get(0)
+            .map(|p| format!("The best AA time is {} by {}.", p.igt, p.name))
+            .unwrap_or_else(|| "I can't find the best time for some reason but it's probably Feinberg. sub 2? probably sub 2.".to_string())
+    }
+
+    pub fn slowest_time(&self) -> String {
+        let lb = return_if_err!(self.get_data());
+        lb.leaderboard.last()
+            .map(|p| format!("The slowest time recorded is {}.", p.igt))
+            .unwrap_or_else(|| "The slowest time is by the one who hasn't played AA.".to_string())
     }
 
     fn get_data(&self) -> Result<&AALeaderboardData, String> {
@@ -144,15 +176,17 @@ impl LeaderboardDownloader {
         }
     }
 
-    async fn fetch(&mut self) -> Option<AALeaderboardData> {
-        self.fetch_csv().await;
-        let csv = self.csv.as_ref()?;
+    async fn fetch(&mut self) -> Result<AALeaderboardData, FetchError> {
+        if let Some(err) = self.fetch_csv().await {
+            return Err(err)
+        }
+        let csv = self.csv.as_ref().ok_or(FetchError::General)?;
         let lines = csv.split('\n').collect_vec();
 
         let mut rank_idx = 0;
         let mut name_idx = 2;
         let mut igt_idx = 3;
-        for (i, cell) in lines.get(1)?.split(',').enumerate() {
+        for (i, cell) in lines.get(1).ok_or(FetchError::General)?.split(',').enumerate() {
             match cell {
                 "#" => rank_idx = i,
                 "Runner" => name_idx = i,
@@ -182,16 +216,29 @@ impl LeaderboardDownloader {
             leaderboard.push(player.clone());
         }
         
-        Some(AALeaderboardData { players, leaderboard })
+        Ok(AALeaderboardData { players, leaderboard })
     }
 
-    async fn fetch_csv(&mut self) -> bool {
-        if self.csv.is_some() { return true }
-        if let Ok(res) = reqwest::get(&self.url).await {
-            self.csv = res.text().await.ok();
-            return self.csv.is_some()
+    async fn fetch_csv(&mut self) -> Option<FetchError> {
+        lazy_static! {
+            static ref CLIENT: Option<Client> = Client::builder()
+                .timeout(Duration::from_secs(10))
+                .build()
+                .ok();
         }
-        return false
+        if CLIENT.is_none() { return Some(FetchError::Internal) }
+        if self.csv.is_some() { return None }
+        match CLIENT.as_ref().unwrap().get(&self.url).send().await {
+            Ok(res) => {
+                self.csv = res.text().await.ok();
+                if self.csv.is_some() { None }
+                else { Some(FetchError::General) }
+            },
+            Err(err) => {
+                if err.is_timeout() { Some(FetchError::Timeout) }
+                else { Some(FetchError::General) }
+            }
+        }
     }
 
     fn make_export_url(spreadsheet_id: &str, worksheet_id: i64) -> String {
@@ -201,4 +248,10 @@ impl LeaderboardDownloader {
         )
     }
 
+}
+
+enum FetchError {
+    General,
+    Timeout,
+    Internal,
 }


### PR DESCRIPTION
Only do a rank search if the parsed number is greater than 0. When converting the rank number to an index, use safe subtraction to prevent crash.

Spreadsheet can sometimes take several minutes to load, which may have been caused by a rate limiter. I've added a timeout to the request.

Added `best`/`fastest` and `slowest` sub-commands to get the fastest or slowest times on the leaderboard.