### PR TITLE
Fix Yahtzee leaderboard ordering and add average score

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -822,7 +822,7 @@ impl IRCBotClient {
                                     .iter()
                                     .map(|e| (e.1.name(), y.get_total_yahtzees(e.0)))
                                     .filter(|t| t.1 > 0)
-                                    .sorted_by_key(|t| t.1)
+                                    .sorted_by(|a, b| b.1.cmp(&a.1))
                                     .take(10)
                                     .map(|t| format!("{}: {}", t.0, t.1))
                                     .join(", ");

--- a/src/yahtzee.rs
+++ b/src/yahtzee.rs
@@ -351,7 +351,7 @@ impl Yahtzee {
             }
         };
 
-        if let Err(err) = serde_json::to_writer(file, self) {
+        if let Err(err) = serde_json::to_writer_pretty(file, self) {
             println!(
                 "Yahtzee failed to serialize for file {}: {}",
                 self.path.display(),

--- a/src/yahtzee.rs
+++ b/src/yahtzee.rs
@@ -425,7 +425,13 @@ impl Yahtzee {
         };
         let rolls = player.total_rolls();
         let turns = player.total_turns();
-        format!("{} has made {} rolls and {} re-rolls. Their best score is {} out of a total {} and they've scored {} yahtzees.", player_name, turns, rolls as i64 - turns as i64, player.best_score().unwrap_or_default(), player.total_score(), player.total_yahtzees())
+        let total_score = player.total_score();
+        let avg_score = if turns == 0 {
+            0_f64
+        } else {
+            total_score as f64 / turns as f64
+        };
+        format!("{} has rolled {} time(s) with {} re-roll(s). Total score: {}. Average score: {:.2}. Best score: {}. Yahtzee(s): {}.", player_name, turns, rolls as i64 - turns as i64, total_score, avg_score, player.best_score().unwrap_or_default(), player.total_yahtzees())
     }
 
     pub fn get_total_yahtzees(&self, player_name: &str) -> u64 {


### PR DESCRIPTION
Fixes ordering of Yahtzees in the leaderboard command and shows the average score in the `stats` sub-command.