### PR TITLE
Add player nick to Yahtzee responses and cooldown re-rolls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ out.txt
 notes.txt
 people.json
 *.swp
+/.vscode
 test.json
 src/stt
 log-*

--- a/src/main.rs
+++ b/src/main.rs
@@ -1336,14 +1336,15 @@ impl IRCBotClient {
                         &"Umm I don't think those are valid dice rolls majj".to_string()
                     );
                 }
+                let nick = pd.name();
                 match yahtzee.play(&user, &saved) {
                     Ok(res) => {
-                        reply_and_continue!(&res);
+                        reply_and_continue!(&res.replace("{ur}", &nick));
                     }
                     Err(err) => match err {
                         YahtzeeError::Private(reason) => println!("{}", &reason),
                         YahtzeeError::Public(display) => {
-                            reply_and_continue!(&display);
+                            reply_and_continue!(&display.replace("{ur}", &nick));
                         }
                     },
                 }


### PR DESCRIPTION
The player's name or nick is now used in the Yahtzee responses instead of just a second-person pronoun to distinguish who the roll is for.

Cool-down has been adjusted to apply to both fresh rolls and re-rolls and the default time has been adjusted to match rollgp.